### PR TITLE
Fix a typo in demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>BLAKE2b-js Demo</title>
+    <title>BLAKE2s-js Demo</title>
   </head>
   <style>
     /* Taken from blake2.net */


### PR DESCRIPTION
The demo page currently is titled "BLAKE2b-js Demo" and is the top result of "BLAKE2b js" on Google.
